### PR TITLE
Make environment panic on error

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,13 +1,13 @@
 package hut
 
 import (
-	"fmt"
 	"errors"
+	"fmt"
 	"regexp"
 
 	"github.com/JustinTulloss/firebase"
-	"github.com/jmoiron/sqlx"
 	"github.com/garyburd/redigo/redis"
+	"github.com/jmoiron/sqlx"
 )
 
 var db *sqlx.DB
@@ -17,10 +17,7 @@ func (s *Service) NewDbClient(driver string) (*sqlx.DB, error) {
 	if db != nil {
 		return db, nil
 	}
-	dbUrl, err := s.Env.GetString("database_url")
-	if err != nil {
-		return nil, err
-	}
+	dbUrl := s.Env.GetString("database_url")
 	conn, err := sqlx.Connect(driver, dbUrl)
 	if err != nil {
 		return nil, err
@@ -29,30 +26,17 @@ func (s *Service) NewDbClient(driver string) (*sqlx.DB, error) {
 }
 
 func (s *Service) NewFirebaseClient() (firebase.Client, error) {
-	baseUrl, err := s.Env.GetString("FIREBASE_URL")
-	if err != nil {
-		return nil, err
-	}
+	baseUrl := s.Env.GetString("FIREBASE_URL")
 	if !firebaseishRe.MatchString(baseUrl) {
 		return nil, errors.New(baseUrl + " does not appear to be a firebase url")
 	}
-	authToken, err := s.Env.GetString("FIREBASE_AUTH")
-	if err != nil {
-		return nil, err
-	}
+	authToken := s.Env.GetString("FIREBASE_AUTH")
 	return firebase.NewClient(baseUrl, authToken, nil), nil
 }
 
-
 func (s *Service) NewRedisClient() (redis.Conn, error) {
-	redisTcpAddr, err := s.Env.GetString("REDIS_PORT_6379_TCP_ADDR")
-	if err != nil {
-		return nil, err
-	}
-	redisPort, err := s.Env.GetString("REDIS_PORT_6379_TCP_PORT")
-	if err != nil {
-		return nil, err
-	}
+	redisTcpAddr := s.Env.GetString("REDIS_PORT_6379_TCP_ADDR")
+	redisPort := s.Env.GetString("REDIS_PORT_6379_TCP_PORT")
 	redisAddress := fmt.Sprintf(
 		"%s:%s",
 		redisTcpAddr,
@@ -64,4 +48,3 @@ func (s *Service) NewRedisClient() (redis.Conn, error) {
 	}
 	return c, nil
 }
-

--- a/env.go
+++ b/env.go
@@ -1,17 +1,16 @@
 package hut
 
 import (
-	"errors"
 	"os"
 	"strconv"
 	"strings"
 )
 
 type Env interface {
-	Get(string) (interface{}, error)
-	GetString(string) (string, error)
-	GetUint(string) (uint64, error)
-	GetInt(string) (int64, error)
+	Get(string) interface{}
+	GetString(string) string
+	GetUint(string) uint64
+	GetInt(string) int64
 	InProd() bool
 }
 
@@ -22,20 +21,28 @@ func getenv(key string) string {
 	return os.Getenv(strings.ToUpper(key))
 }
 
-func (e *OsEnv) Get(key string) (interface{}, error) {
+func (e *OsEnv) Get(key string) interface{} {
 	return e.GetString(key)
 }
 
-func (*OsEnv) GetString(key string) (string, error) {
-	return getenv(key), nil
+func (*OsEnv) GetString(key string) string {
+	return getenv(key)
 }
 
-func (*OsEnv) GetUint(key string) (uint64, error) {
-	return strconv.ParseUint(getenv(key), 10, 64)
+func (*OsEnv) GetUint(key string) uint64 {
+	val, err := strconv.ParseUint(getenv(key), 10, 64)
+	if err != nil {
+		panic("Could not parse " + key)
+	}
+	return val
 }
 
-func (*OsEnv) GetInt(key string) (int64, error) {
-	return strconv.ParseInt(getenv(key), 10, 64)
+func (*OsEnv) GetInt(key string) int64 {
+	val, err := strconv.ParseInt(getenv(key), 10, 64)
+	if err != nil {
+		panic("Could not parse " + key)
+	}
+	return val
 }
 
 func (e *OsEnv) InProd() bool {
@@ -48,32 +55,32 @@ func NewOsEnv() *OsEnv {
 
 type MapEnv map[string]interface{}
 
-func (e MapEnv) Get(key string) (interface{}, error) {
-	return e[key], nil
+func (e MapEnv) Get(key string) interface{} {
+	return e[key]
 }
 
-func (e MapEnv) GetString(key string) (string, error) {
+func (e MapEnv) GetString(key string) string {
 	s, ok := e[key].(string)
 	if !ok {
-		return "", errors.New(key + " is not a string")
+		panic("Could not find " + key + " in env")
 	}
-	return s, nil
+	return s
 }
 
-func (e MapEnv) GetUint(key string) (uint64, error) {
+func (e MapEnv) GetUint(key string) uint64 {
 	n, ok := e[key].(uint64)
 	if !ok {
-		return 0, errors.New(key + " is not a uint64")
+		panic("Could not get " + key + " as a uint")
 	}
-	return n, nil
+	return n
 }
 
-func (e MapEnv) GetInt(key string) (int64, error) {
+func (e MapEnv) GetInt(key string) int64 {
 	n, ok := e[key].(int64)
 	if !ok {
-		return 0, errors.New(key + " is not a int64")
+		panic("Could not get " + key + " as an int")
 	}
-	return n, nil
+	return n
 }
 
 func (e MapEnv) InProd() bool {

--- a/env_test.go
+++ b/env_test.go
@@ -27,8 +27,7 @@ var _ = Describe("OsEnv", func() {
 		}
 	})
 	It("Can get configuration", func() {
-		val, err := s.Env.Get("TEST")
-		Expect(err).ToNot(HaveOccurred())
+		val := s.Env.Get("TEST")
 		Expect(val.(string)).To(Equal("secrets, maybe"))
 	})
 	It("can get strings", func() {
@@ -37,14 +36,12 @@ var _ = Describe("OsEnv", func() {
 	It("Can get uints", func() {
 		os.Setenv("NUMBERS", "1234")
 		Expect(s.Env.GetUint("NUMBERS")).To(Equal(uint64(1234)))
-		_, err := s.Env.GetUint("TEST")
-		Expect(err).To(HaveOccurred())
+		Expect(func() { s.Env.GetUint("TEST") }).To(Panic())
 	})
 	It("Can get ints", func() {
 		os.Setenv("NUMBERS", "5678")
 		Expect(s.Env.GetInt("NUMBERS")).To(Equal(int64(5678)))
-		_, err := s.Env.GetInt("TEST")
-		Expect(err).To(HaveOccurred())
+		Expect(func() { s.Env.GetInt("TEST") }).To(Panic())
 	})
 	It("says we're in prod if the environment does", func() {
 		Expect(s.Env.InProd()).To(BeFalse())

--- a/service.go
+++ b/service.go
@@ -56,10 +56,7 @@ func NewService(r *mux.Router) *Service {
 func (s *Service) Start() {
 	http.Handle("/", handlers.CombinedLoggingHandler(os.Stdout, s.Router))
 
-	port, err := s.Env.GetString("port")
-	if err != nil {
-		log.Fatal("Could not get port to start on: ", err)
-	}
+	port := s.Env.GetString("port")
 	// Actually start the server
 	port = fmt.Sprintf(":%s", port)
 	log.Printf("Server started on %s\n", port)


### PR DESCRIPTION
The correct behavior for a service that can't get something out of its
environment is to panic and die. The callers always had to do this
themselves, now we do it for you.

Makes it much more straightforward to use the environment.
