### PR TITLE
Stats support for hut

### DIFF
--- a/env.go
+++ b/env.go
@@ -1,6 +1,7 @@
 package hut
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -11,12 +12,25 @@ type Env interface {
 	GetString(string) string
 	GetUint(string) uint64
 	GetInt(string) int64
+	GetTCPServiceAddress(string, int) string
+	GetUDPServiceAddress(string, int) string
 	InProd() bool
 }
 
 // Reads the environment from the OS environment
 type OsEnv struct{}
 
+// Given a docker link like name, pull the connection details out of the
+// environment. https://docs.docker.com/userguide/dockerlinks/#environment-variables
+func makeDockerLinkAddress(env Env, serviceName string, port int, protocol string) string {
+	prefix := fmt.Sprintf("%s_PORT_%d_%s",
+		strings.ToUpper(serviceName), port, protocol)
+	return fmt.Sprintf(
+		"%s:%s",
+		env.GetString(fmt.Sprintf("%s_ADDR", prefix)),
+		env.GetString(fmt.Sprintf("%s_PORT", prefix)),
+	)
+}
 func getenv(key string) string {
 	return os.Getenv(strings.ToUpper(key))
 }
@@ -43,6 +57,14 @@ func (*OsEnv) GetInt(key string) int64 {
 		panic("Could not parse " + key)
 	}
 	return val
+}
+
+func (e *OsEnv) GetTCPServiceAddress(name string, port int) string {
+	return makeDockerLinkAddress(e, name, port, "TCP")
+}
+
+func (e *OsEnv) GetUDPServiceAddress(name string, port int) string {
+	return makeDockerLinkAddress(e, name, port, "UDP")
 }
 
 func (e *OsEnv) InProd() bool {
@@ -81,6 +103,14 @@ func (e MapEnv) GetInt(key string) int64 {
 		panic("Could not get " + key + " as an int")
 	}
 	return n
+}
+
+func (e MapEnv) GetTCPServiceAddress(name string, port int) string {
+	return makeDockerLinkAddress(e, name, port, "TCP")
+}
+
+func (e MapEnv) GetUDPServiceAddress(name string, port int) string {
+	return makeDockerLinkAddress(e, name, port, "UDP")
 }
 
 func (e MapEnv) InProd() bool {

--- a/env_test.go
+++ b/env_test.go
@@ -53,6 +53,12 @@ var _ = Describe("OsEnv", func() {
 		os.Setenv("SERVICE_PORT_1337_UDP_PORT", "7")
 		Expect(s.Env.GetUDPServiceAddress("service", 1337)).To(Equal("testerator:7"))
 	})
+	It("returns empty string if environment is not set up for service", func() {
+		Expect(s.Env.GetUDPServiceAddress("nullservice", 1337)).To(Equal(""))
+	})
+	It("panics if you use the must version", func() {
+		Expect(func() { s.Env.MustGetTCPServiceAddress("nullservice", 1337) }).To(Panic())
+	})
 	It("says we're in prod if the environment does", func() {
 		Expect(s.Env.InProd()).To(BeFalse())
 		os.Setenv("ENV", "prod")

--- a/env_test.go
+++ b/env_test.go
@@ -43,6 +43,16 @@ var _ = Describe("OsEnv", func() {
 		Expect(s.Env.GetInt("NUMBERS")).To(Equal(int64(5678)))
 		Expect(func() { s.Env.GetInt("TEST") }).To(Panic())
 	})
+	It("can compose a tcp service address", func() {
+		os.Setenv("SERVICE_PORT_1337_TCP_ADDR", "testerator")
+		os.Setenv("SERVICE_PORT_1337_TCP_PORT", "7")
+		Expect(s.Env.GetTCPServiceAddress("service", 1337)).To(Equal("testerator:7"))
+	})
+	It("can compose a udp service address", func() {
+		os.Setenv("SERVICE_PORT_1337_UDP_ADDR", "testerator")
+		os.Setenv("SERVICE_PORT_1337_UDP_PORT", "7")
+		Expect(s.Env.GetUDPServiceAddress("service", 1337)).To(Equal("testerator:7"))
+	})
 	It("says we're in prod if the environment does", func() {
 		Expect(s.Env.InProd()).To(BeFalse())
 		os.Setenv("ENV", "prod")

--- a/stats.go
+++ b/stats.go
@@ -1,0 +1,22 @@
+package hut
+
+import (
+	"github.com/cactus/go-statsd-client/statsd"
+)
+
+type Statter statsd.Statter
+
+func (s *Service) NewStatsd() (client Statter) {
+	address := s.Env.GetUDPServiceAddress("STATSD", 8125)
+	if address == "" {
+		client, _ = statsd.NewNoop()
+		return client
+	}
+	// TODO: put the right prefix in here
+	client, err := statsd.New(address, s.name)
+	if err != nil {
+		s.Log.Error().Printf("Could not connect to statsd: %s\n", err)
+		client, _ = statsd.NewNoop()
+	}
+	return
+}

--- a/stats.go
+++ b/stats.go
@@ -12,7 +12,6 @@ func (s *Service) NewStatsd() (client Statter) {
 		client, _ = statsd.NewNoop()
 		return client
 	}
-	// TODO: put the right prefix in here
 	client, err := statsd.New(address, s.name)
 	if err != nil {
 		s.Log.Error().Printf("Could not connect to statsd: %s\n", err)


### PR DESCRIPTION
- Adds some convenience functions for getting docker link environment variables
- Adds a `Stats` member to the service, which you can use to record whatever stats you want
- Adds a `name` to the service, which is helpful when publishing information about the service
